### PR TITLE
Feature/103 combine lobby and gameview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ crashlytics-build.properties
 .vsconfig
 # Clones
 FortressForge_clone_0
+FortressForge_clone_1
+FortressForge_clone_2

--- a/FortressForge/.gitignore
+++ b/FortressForge/.gitignore
@@ -79,3 +79,5 @@ crashlytics-build.properties
 /.utmp/*
 # Manual addition for non Template inclusions
 .vsconfig
+
+/UIElementsSchema/

--- a/FortressForge/Assets/Resources/Prefabs/ServerManager.prefab
+++ b/FortressForge/Assets/Resources/Prefabs/ServerManager.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 5614024977004006181}
   - component: {fileID: 3768263624540972569}
   - component: {fileID: 3245230822600007962}
+  - component: {fileID: -1787639390863650392}
   m_Layer: 0
   m_Name: ServerManager
   m_TagString: Untagged
@@ -45,10 +46,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b57e3c2a5f244d78b3e092b966ebe9e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _componentIndexCache: 255
-  _addedNetworkObject: {fileID: 3245230822600007962}
-  _networkObjectCache: {fileID: 0}
-  _config: {fileID: 11400000, guid: 5a14fda24b5e45a48a6e66352b2d350d, type: 2}
 --- !u!114 &3245230822600007962
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -65,7 +62,8 @@ MonoBehaviour:
   <ComponentIndex>k__BackingField: 0
   <PredictedSpawn>k__BackingField: {fileID: 0}
   <PredictedOwner>k__BackingField: {fileID: 0}
-  NetworkBehaviours: []
+  NetworkBehaviours:
+  - {fileID: -1787639390863650392}
   InitializedParentNetworkBehaviour: {fileID: 0}
   InitializedNestedNetworkObjects: []
   RuntimeParentNetworkBehaviour: {fileID: 0}
@@ -90,12 +88,27 @@ MonoBehaviour:
   _spectatorInterpolation: 2
   _enableTeleport: 0
   _teleportThreshold: 1
-  <PrefabId>k__BackingField: 65535
+  <PrefabId>k__BackingField: 1
   <SpawnableCollectionId>k__BackingField: 0
   <AssetPathHash>k__BackingField: 2164335919683823945
   <SceneId>k__BackingField: 0
   SerializedTransformProperties:
     Position: {x: 0, y: 0, z: 0}
-    Rotation: {x: 0, y: 0, z: 0, w: 0}
-    Scale: {x: 0, y: 0, z: 0}
-    IsValid: 0
+    Rotation: {x: -0, y: -0, z: -0, w: 1}
+    Scale: {x: 1, y: 1, z: 1}
+    IsValid: 1
+--- !u!114 &-1787639390863650392
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4232710597697346239}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8a6a39c46bf52104ba8efe3100bce3f7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _componentIndexCache: 0
+  _addedNetworkObject: {fileID: 3245230822600007962}
+  _networkObjectCache: {fileID: 3245230822600007962}

--- a/FortressForge/Assets/Scenes/GameView.unity
+++ b/FortressForge/Assets/Scenes/GameView.unity
@@ -279,9 +279,9 @@ MonoBehaviour:
   PitchSpeed: 40
   MouseWheelZoomSpeed: 1
   ButtonsZoomSpeed: 5
+  Config: {fileID: 11400000, guid: 5a14fda24b5e45a48a6e66352b2d350d, type: 2}
   PitchLimits: {x: 89, y: 0}
   zoomLimits: {x: 2, y: 1000}
-  _config: {fileID: 11400000, guid: 5a14fda24b5e45a48a6e66352b2d350d, type: 2}
 --- !u!114 &330585549
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -807,7 +807,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &2164771898202891164
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -830,7 +830,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3760083159665761632}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26b716c41e9b56b4baafaf13a523ba2e, type: 3}
   m_Name: 
@@ -955,9 +955,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b57e3c2a5f244d78b3e092b966ebe9e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _componentIndexCache: 255
-  _addedNetworkObject: {fileID: 2565508449727063749}
-  _networkObjectCache: {fileID: 0}
 --- !u!1 &4811124693230337076
 GameObject:
   m_ObjectHideFlags: 0

--- a/FortressForge/Assets/Scenes/GameView.unity
+++ b/FortressForge/Assets/Scenes/GameView.unity
@@ -955,6 +955,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3b57e3c2a5f244d78b3e092b966ebe9e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  PlayerManagerPrefab: {fileID: 6811327856764417488, guid: 2dce4e688cfb40743b0aa4caa8f44a2e, type: 3}
 --- !u!1 &4811124693230337076
 GameObject:
   m_ObjectHideFlags: 0

--- a/FortressForge/Assets/Scenes/LobbyScene.unity
+++ b/FortressForge/Assets/Scenes/LobbyScene.unity
@@ -163,7 +163,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &450985575
+--- !u!1 &600518322
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -171,10 +171,12 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 450985578}
-  - component: {fileID: 450985577}
-  - component: {fileID: 450985576}
-  - component: {fileID: 450985579}
+  - component: {fileID: 600518328}
+  - component: {fileID: 600518327}
+  - component: {fileID: 600518326}
+  - component: {fileID: 600518325}
+  - component: {fileID: 600518324}
+  - component: {fileID: 600518323}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -182,21 +184,119 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!81 &450985576
+--- !u!114 &600518323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600518322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 23ee6c631d45ead47930849e48c97567, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: CameraControls
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
+--- !u!114 &600518324
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600518322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18b7da322d3a3414381ac04cb70f808a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Yaw: 0
+  Pitch: 45
+  Zoom: 100
+  TargetPosition: {x: 3089, y: 0, z: 10559}
+  MoveSpeed: 300
+  RotationSpeed: 50
+  PitchSpeed: 40
+  MouseWheelZoomSpeed: 1
+  ButtonsZoomSpeed: 5
+  Config: {fileID: 11400000, guid: 5a14fda24b5e45a48a6e66352b2d350d, type: 2}
+  PitchLimits: {x: 89, y: 0}
+  zoomLimits: {x: 2, y: 1000}
+--- !u!114 &600518325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600518322}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 1
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_AllowHDROutput: 1
+  m_UseScreenCoordOverride: 0
+  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+  m_TaaSettings:
+    m_Quality: 3
+    m_FrameInfluence: 0.1
+    m_JitterScale: 1
+    m_MipBias: 0
+    m_VarianceClampScale: 0.9
+    m_ContrastAdaptiveSharpening: 0
+--- !u!81 &600518326
 AudioListener:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 450985575}
+  m_GameObject: {fileID: 600518322}
   m_Enabled: 1
---- !u!20 &450985577
+--- !u!20 &600518327
 Camera:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 450985575}
+  m_GameObject: {fileID: 600518322}
   m_Enabled: 1
   serializedVersion: 2
   m_ClearFlags: 1
@@ -222,7 +322,7 @@ Camera:
     width: 1
     height: 1
   near clip plane: 0.3
-  far clip plane: 1000
+  far clip plane: 100000
   field of view: 60
   orthographic: 0
   orthographic size: 5
@@ -241,65 +341,21 @@ Camera:
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
---- !u!4 &450985578
+--- !u!4 &600518328
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 450985575}
+  m_GameObject: {fileID: 600518322}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalRotation: {x: 0.26912743, y: 0.39926758, z: -0.12384455, w: 0.86765105}
+  m_LocalPosition: {x: 3000, y: 29.457, z: 9000}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &450985579
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 450985575}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_RenderShadows: 1
-  m_RequiresDepthTextureOption: 2
-  m_RequiresOpaqueTextureOption: 2
-  m_CameraType: 0
-  m_Cameras: []
-  m_RendererIndex: -1
-  m_VolumeLayerMask:
-    serializedVersion: 2
-    m_Bits: 1
-  m_VolumeTrigger: {fileID: 0}
-  m_VolumeFrameworkUpdateModeOption: 2
-  m_RenderPostProcessing: 0
-  m_Antialiasing: 0
-  m_AntialiasingQuality: 2
-  m_StopNaN: 0
-  m_Dithering: 0
-  m_ClearDepth: 1
-  m_AllowXRRendering: 1
-  m_AllowHDROutput: 1
-  m_UseScreenCoordOverride: 0
-  m_ScreenSizeOverride: {x: 0, y: 0, z: 0, w: 0}
-  m_ScreenCoordScaleBias: {x: 0, y: 0, z: 0, w: 0}
-  m_RequiresDepthTexture: 0
-  m_RequiresColorTexture: 0
-  m_Version: 2
-  m_TaaSettings:
-    m_Quality: 3
-    m_FrameInfluence: 0.1
-    m_JitterScale: 1
-    m_MipBias: 0
-    m_VarianceClampScale: 0.9
-    m_ContrastAdaptiveSharpening: 0
+  m_LocalEulerAnglesHint: {x: 34.466, y: 49.421, z: 0}
 --- !u!1 &885907597
 GameObject:
   m_ObjectHideFlags: 0
@@ -331,7 +387,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   lobbyViewDoc: {fileID: 1540258046}
   gameRoomViewDoc: {fileID: 978647737}
-  nextScene: GameView
   lobbyScene: LobbyScene
 --- !u!4 &885907599
 Transform:
@@ -534,7 +589,7 @@ MonoBehaviour:
 SceneRoots:
   m_ObjectHideFlags: 0
   m_Roots:
-  - {fileID: 450985578}
+  - {fileID: 600518328}
   - {fileID: 978647738}
   - {fileID: 1540258047}
   - {fileID: 885907599}

--- a/FortressForge/Assets/Scenes/Tests/GameOverlayTesting.unity
+++ b/FortressForge/Assets/Scenes/Tests/GameOverlayTesting.unity
@@ -745,7 +745,7 @@ MonoBehaviour:
   <PrefabId>k__BackingField: 65535
   <SpawnableCollectionId>k__BackingField: 0
   <AssetPathHash>k__BackingField: 0
-  <SceneId>k__BackingField: 0
+  <SceneId>k__BackingField: 4143905927
   SerializedTransformProperties:
     Position: {x: 0, y: 0, z: 0}
     Rotation: {x: 0, y: 0, z: 0, w: 0}

--- a/FortressForge/Assets/Scripts/BuildingSystem/BuildManager/BuildViewController.cs
+++ b/FortressForge/Assets/Scripts/BuildingSystem/BuildManager/BuildViewController.cs
@@ -1,9 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using FishNet;
 using FishNet.Object;
 using FortressForge.BuildingSystem.BuildingData;
-using FortressForge.Economy;
 using FortressForge.GameInitialization;
 using FortressForge.HexGrid;
 using FortressForge.HexGrid.Data;
@@ -30,6 +30,8 @@ namespace FortressForge.BuildingSystem.BuildManager
         private List<BaseBuildingTemplate> AvailableBuildings => _config.availableBuildings;
 
         private BuildActions _input;
+        
+        public static event Action OnExitBuildModeEvent;
 
         public void Init(List<HexGridData> hexGridData, GameStartConfiguration config,
             HexGridManager hexGridManager)
@@ -204,6 +206,8 @@ namespace FortressForge.BuildingSystem.BuildManager
         private void ExitBuildMode()
         {
             if (!IsPreviewMode) return;
+            
+            OnExitBuildModeEvent?.Invoke();
 
             Destroy(_previewBuilding);
             _selectedBuildingIndex = -1;

--- a/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using FishNet;
@@ -20,36 +21,37 @@ namespace FortressForge.GameInitialization
 {
     public class PlayerInitializationManager : NetworkBehaviour
     {
-        [Header("Game Start Configuration")]
-        [SerializeField] private GameStartConfiguration _gameStartConfiguration;
+        [Header("Game Start Configuration")] [SerializeField]
+        private GameStartConfiguration _gameStartConfiguration;
+
         [SerializeField] private GameSessionStartConfiguration _gameSessionStartConfiguration;
-        
+
         public override void OnStartClient()
         {
             // Initialize Client for each player so ObserverRpc can be used
             StartCoroutine(WaitForInitialization());
         }
-        
+
         public override void OnStartServer()
         {
             // Initialize Server for each player so ObserverRpc can be used. This gets called on each joining client on server side.
             // This is a bit of a hack, for optimization but higher complexity you could differentiate between server and client more.
             Init();
         }
-        
+
         /// <summary>
         /// Waits for the initialization of the HexGridManager and the AllGrids list.
         /// </summary>
         /// <returns>IEnumerator</returns>
         private IEnumerator WaitForInitialization()
         {
-            while (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "LobbyScene" || 
-                   HexGridManager.Instance is null || 
-                   HexGridManager.Instance.AllGrids is null || 
-                   HexGridManager.Instance.AllGrids.Count == 0)
-            {
-                yield return null;
-            }
+            yield return new WaitUntil(() =>
+                    UnityEngine.SceneManagement.SceneManager.GetActiveScene().name != "LobbyScene" &&
+                    HexGridManager.Instance != null &&
+                    HexGridManager.Instance.AllGrids != null &&
+                    HexGridManager.Instance.AllGrids.Count > 0
+                , new TimeSpan(0, 0, 10),
+                () => Debug.Log("HexGridManager is not initialized after 10 seconds."));
             Init();
         }
 
@@ -66,42 +68,42 @@ namespace FortressForge.GameInitialization
 
             // Currently takes the playerId from the owner of this object
             int playerId = Owner.ClientId;
-            
+
             // Take the clientId from the owner of this object, also called the playerId
             int gridId = _gameSessionStartConfiguration.GridPlayerIdTuples
                 .First(gpit => gpit.PlayerId == playerId).HexGridId;
             HexGridData selectedGrid = HexGridManager.Instance.AllGrids[gridId];
-            
+
             // initialize the grid view so allgrids is set
             BuildViewController buildViewController = gameObject.GetComponent<BuildViewController>();
             // We only initialize the view for the selected grid,
             // theoretically you could add multiple grids per player here. But EconomySystem is only one per player. So there mustn't be overlaps.
-            buildViewController.Init(new List<HexGridData>{ selectedGrid }, 
+            buildViewController.Init(new List<HexGridData> { selectedGrid },
                 _gameStartConfiguration, HexGridManager.Instance);
-            
+
             // After creating EconomySystem
             var economySync = gameObject.GetComponent<EconomySync>();
             EconomyController economyController = gameObject.AddComponent<EconomyController>();
-            
+
             // Only the server needs to initialize the EconomySystem
             if (IsServerInitialized && !IsClientInitialized)
             {
                 economySync.Init(selectedGrid.EconomySystem);
                 economyController.Init(selectedGrid.EconomySystem);
             }
-            
+
             // Initialize view only on clients, server doesn't need the individual views
             if (IsClientInitialized && IsOwner)
             {
                 Vector3 gridOrigin = _gameSessionStartConfiguration.HexGridOrigins[gridId];
-                
+
                 Camera mainCamera = Camera.main;
                 if (mainCamera == null)
                 {
                     Debug.LogError("Main camera not found!");
                     return;
                 }
-                
+
                 mainCamera.GetComponent<CameraController>()
                     .SetTargetPosition(gridOrigin);
 

--- a/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using FishNet;
 using FishNet.Object;
@@ -26,13 +27,25 @@ namespace FortressForge.GameInitialization
         public override void OnStartClient()
         {
             // Initialize Client for each player so ObserverRpc can be used
-            Init();
+            StartCoroutine(WaitForInitialization());
         }
         
         public override void OnStartServer()
         {
             // Initialize Server for each player so ObserverRpc can be used. This gets called on each joining client on server side.
             // This is a bit of a hack, for optimization but higher complexity you could differentiate between server and client more.
+            Init();
+        }
+        
+        private IEnumerator WaitForInitialization()
+        {
+            while (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "LobbyScene" || 
+                   HexGridManager.Instance is null || 
+                   HexGridManager.Instance.AllGrids is null || 
+                   HexGridManager.Instance.AllGrids.Count == 0)
+            {
+                yield return null;
+            }
             Init();
         }
 

--- a/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/PlayerInitializationManager.cs
@@ -37,6 +37,10 @@ namespace FortressForge.GameInitialization
             Init();
         }
         
+        /// <summary>
+        /// Waits for the initialization of the HexGridManager and the AllGrids list.
+        /// </summary>
+        /// <returns>IEnumerator</returns>
         private IEnumerator WaitForInitialization()
         {
             while (UnityEngine.SceneManagement.SceneManager.GetActiveScene().name == "LobbyScene" || 
@@ -49,6 +53,9 @@ namespace FortressForge.GameInitialization
             Init();
         }
 
+        /// <summary>
+        /// Initializes the player and the grid view.
+        /// </summary>
         private void Init()
         {
             if (_gameStartConfiguration == null)

--- a/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
@@ -1,24 +1,53 @@
-﻿using System;
-using FishNet;
-using FishNet.Object;
-using FortressForge.BuildingSystem.BuildManager;
-using FortressForge.Economy;
-using FortressForge.HexGrid;
+﻿using System.Collections.Generic;
 using UnityEngine;
+using FishNet;
+using FishNet.Connection;
 
 namespace FortressForge.GameInitialization
 {
-    public class ServerInitializationManager : NetworkBehaviour
+    public class ServerInitializationManager : MonoBehaviour
     {
-        public static ServerInitializationManager Instance { get; private set; }
+        private static ServerInitializationManager Instance { get; set; }
 
-        /// <summary>
-        /// Gets called once when the server starts.
-        /// Server initialization is done here.
-        /// </summary>
-        public override void OnStartServer() // TODO Consider removing this if no use case arises
+        private void Awake()
         {
-            Instance = this;
+            if (Instance == null)
+            {
+                Instance = this;
+                DontDestroyOnLoad(gameObject);
+            }
+            else
+            {
+                Destroy(gameObject);
+            }
+        }
+
+        private void Start()
+        {
+            StartGame();
+        }
+
+        private void StartGame()
+        {
+            if (InstanceFinder.IsServerStarted)
+            {
+                Debug.Log("Server startet das Spiel.");
+                foreach (KeyValuePair<int, NetworkConnection> client in InstanceFinder.ServerManager.Clients)
+                {
+                    Debug.Log($"Spawne PlayerManager für Client: {client.Value.ClientId}");
+                    GameObject playerManager = Instantiate(Resources.Load<GameObject>("Prefabs/PlayerManager"));
+                    InstanceFinder.ServerManager.Spawn(playerManager, client.Value);
+                }
+            }
+            else if (InstanceFinder.IsClientStarted)
+            {
+                Debug.Log("Client ist bereit.");
+                // Fügen Sie hier die Logik für den Client hinzu
+            }
+            else
+            {
+                Debug.Log("Server und Client sind nicht gestartet.");
+            }
         }
     }
 }

--- a/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
@@ -11,6 +11,9 @@ namespace FortressForge.GameInitialization
     public class ServerInitializationManager : MonoBehaviour
     {
         private static ServerInitializationManager Instance { get; set; }
+        
+        [SerializeField]
+        private GameObject PlayerManagerPrefab;
 
         private void Awake()
         {
@@ -42,8 +45,8 @@ namespace FortressForge.GameInitialization
                 Debug.Log("Server startet das Spiel.");
                 foreach (KeyValuePair<int, NetworkConnection> client in InstanceFinder.ServerManager.Clients)
                 {
-                    Debug.Log($"Spawne PlayerManager für Client: {client.Value.ClientId}");
-                    GameObject playerManager = Instantiate(Resources.Load<GameObject>("Prefabs/PlayerManager"));
+                    Debug.Log($"Spawn PlayerManager for Client: {client.Value.ClientId}");
+                    GameObject playerManager = Instantiate(PlayerManagerPrefab);
                     InstanceFinder.ServerManager.Spawn(playerManager, client.Value);
                 }
             }

--- a/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
+++ b/FortressForge/Assets/Scripts/GameInitialization/ServerInitializationManager.cs
@@ -5,6 +5,9 @@ using FishNet.Connection;
 
 namespace FortressForge.GameInitialization
 {
+    /// <summary>
+    /// Manages the initialization of the server and the start of the game.
+    /// </summary>
     public class ServerInitializationManager : MonoBehaviour
     {
         private static ServerInitializationManager Instance { get; set; }
@@ -27,6 +30,11 @@ namespace FortressForge.GameInitialization
             StartGame();
         }
 
+        /// <summary>
+        /// Starts the game by executing logic for the server and client.
+        /// - If the server is active, PlayerManager objects are spawned for all connected clients.
+        /// - If the client is active, corresponding logic is executed (currently empty).
+        /// </summary>
         private void StartGame()
         {
             if (InstanceFinder.IsServerStarted)

--- a/FortressForge/Assets/Scripts/Network/BootstrapSceneManager.cs
+++ b/FortressForge/Assets/Scripts/Network/BootstrapSceneManager.cs
@@ -27,6 +27,7 @@ namespace FortressForge.Network
             }
 
             SceneLoadData sceneLoadData = new(sceneName);
+            sceneLoadData.ReplaceScenes = ReplaceOption.All;
             InstanceFinder.SceneManager.LoadGlobalScenes(sceneLoadData);
         }
 
@@ -36,12 +37,12 @@ namespace FortressForge.Network
         /// <param name="sceneName">The name of the scene to unload</param>
         public void UnloadScene(string sceneName)
         {
-            if (!InstanceFinder.IsServerStarted)
+            if (!InstanceFinder.IsServerStarted) 
             {
                 Debug.Log("Server not started. Cannot unload scene.");
                 return;
             }
-
+            
             SceneUnloadData sceneUnloadData = new(sceneName);
             InstanceFinder.SceneManager.UnloadGlobalScenes(sceneUnloadData);
         }

--- a/FortressForge/Assets/Scripts/UI/BottomOverlayViewGenerator.cs
+++ b/FortressForge/Assets/Scripts/UI/BottomOverlayViewGenerator.cs
@@ -33,6 +33,13 @@ namespace FortressForge.UI
 
             LoadBuildingSelectorView();
             AlignTabHeadersWithTrapezBorder();
+
+            BuildViewController.OnExitBuildModeEvent += HandleExitBuildMode;
+        }
+
+        private void OnDisable()
+        {
+            BuildViewController.OnExitBuildModeEvent -= HandleExitBuildMode;
         }
 
         /// <summary>
@@ -224,6 +231,17 @@ namespace FortressForge.UI
                 SelectBuilding(index);
                 Debug.Log($"Selected building: {building.name}");
             });
+        }
+
+        /// <summary>
+        /// Handles the exit build mode event by removing the selected card from the class list.
+        /// </summary>
+        private void HandleExitBuildMode()
+        {
+            if (_selectedCard is null) return;
+            _selectedCard.RemoveFromClassList("selected-building-card");
+            _selectedCard = null;
+            Debug.Log("Building card unselected.");
         }
     }
 }

--- a/FortressForge/Assets/Scripts/UI/CustomVisualElements/AutoSizeLabel.cs
+++ b/FortressForge/Assets/Scripts/UI/CustomVisualElements/AutoSizeLabel.cs
@@ -10,6 +10,8 @@ namespace FortressForge.UI.CustomVisualElements
     /// </summary>
     public class AutoSizeLabel : Label
     {
+        private const int DEFAULT_FONT_SIZE = 19;
+
         /// <summary>
         /// A nested class for serialized data specific to the AutoSizeLabel.
         /// </summary>
@@ -31,6 +33,12 @@ namespace FortressForge.UI.CustomVisualElements
             if (hierarchy.parent == null) return;
 
             Vector2 parentSize = hierarchy.parent.layout.size;
+
+            if (float.IsNaN(parentSize.x) || float.IsNaN(parentSize.y))
+            {
+                style.fontSize = DEFAULT_FONT_SIZE;
+                return;
+            }
 
             float horizontalMargins = resolvedStyle.marginLeft + resolvedStyle.marginRight;
             float verticalMargins = resolvedStyle.marginTop + resolvedStyle.marginBottom;

--- a/FortressForge/Assets/Scripts/UI/CustomVisualElements/TrapezElement.cs
+++ b/FortressForge/Assets/Scripts/UI/CustomVisualElements/TrapezElement.cs
@@ -250,7 +250,17 @@ namespace FortressForge.UI.CustomVisualElements
         {
             Vector2 mousePosition = MousePositionNdc;
             Vector2 flippedPosition = new(mousePosition.x, 1 - mousePosition.y);
-            Vector2 adjustedPosition = flippedPosition * panel.visualTree.layout.size;
+            Vector2 panelSize;
+            try
+            {
+                panelSize = panel.visualTree.layout.size;
+            }
+            catch (System.Exception e)
+            {
+                return Vector2.zero;
+            }
+
+            Vector2 adjustedPosition = flippedPosition * panelSize;
             return this.WorldToLocal(adjustedPosition);
         }
 

--- a/FortressForge/Assets/Scripts/UI/Manager/ViewManager.cs
+++ b/FortressForge/Assets/Scripts/UI/Manager/ViewManager.cs
@@ -16,8 +16,15 @@ namespace FortressForge.UI.Manager
     {
         [SerializeField] private UIDocument lobbyViewDoc;
         [SerializeField] private UIDocument gameRoomViewDoc;
-        [SerializeField] private string nextScene = "GameView";
         [SerializeField] private string lobbyScene = "LobbyScene";
+
+        private string _nextScene = "GameView";
+
+        public string NextScene
+        {
+            get => _nextScene;
+            set => _nextScene = value;
+        }
 
         private UIDocument _currentView;
         private GameRoomView _gameRoomView;
@@ -43,6 +50,8 @@ namespace FortressForge.UI.Manager
             SetupLobbyButtons();
 
             _gameRoomView = FindFirstObjectByType<GameRoomView>();
+
+            PopulateTextFieldsForFasterDevelopment();
         }
 
         /// <summary>
@@ -196,7 +205,7 @@ namespace FortressForge.UI.Manager
             };
 
             if (!stoppedStates.Contains(args.ConnectionState)) return;
-            
+
             Debug.Log("❌ Verbindung zum Server verloren! ClientConnection");
             ShowView(lobbyViewDoc);
         }
@@ -235,8 +244,7 @@ namespace FortressForge.UI.Manager
         private void StartMatch()
         {
             BootstrapSceneManager sceneManager = FindAnyObjectByType<BootstrapSceneManager>();
-            sceneManager.UnloadScene(lobbyScene);
-            sceneManager.LoadScene(nextScene);
+            sceneManager.LoadScene(_nextScene);
         }
 
         /// <summary>
@@ -329,20 +337,11 @@ namespace FortressForge.UI.Manager
 
             Vector3 originalPosition = lobbyContainer.transform.position;
 
-            lobbyContainer.schedule.Execute(() =>
-            {
-                lobbyContainer.transform.position = originalPosition + new Vector3(SHAKE_STRENGTH, 0, 0);
-            }).StartingIn(50);
+            lobbyContainer.schedule.Execute(() => { lobbyContainer.transform.position = originalPosition + new Vector3(SHAKE_STRENGTH, 0, 0); }).StartingIn(50);
 
-            lobbyContainer.schedule.Execute(() =>
-            {
-                lobbyContainer.transform.position = originalPosition - new Vector3(SHAKE_STRENGTH, 0, 0);
-            }).StartingIn(100);
+            lobbyContainer.schedule.Execute(() => { lobbyContainer.transform.position = originalPosition - new Vector3(SHAKE_STRENGTH, 0, 0); }).StartingIn(100);
 
-            lobbyContainer.schedule.Execute(() =>
-            {
-                lobbyContainer.transform.position = originalPosition + new Vector3(SHAKE_STRENGTH / 2, 0, 0);
-            }).StartingIn(150);
+            lobbyContainer.schedule.Execute(() => { lobbyContainer.transform.position = originalPosition + new Vector3(SHAKE_STRENGTH / 2, 0, 0); }).StartingIn(150);
 
             lobbyContainer.schedule.Execute(() => { lobbyContainer.transform.position = originalPosition; })
                 .StartingIn(200);
@@ -487,6 +486,23 @@ namespace FortressForge.UI.Manager
         public PlayerClient GetPlayerClient()
         {
             return _playerClient;
+        }
+
+        private void PopulateTextFieldsForFasterDevelopment()
+        {
+            // set the name of the player to "TestPlayer" + random number
+            TextField playerNameField = lobbyViewDoc.rootVisualElement.Q<TextField>("PlayerNameTextField");
+            if (playerNameField != null)
+            {
+                playerNameField.value = "TestPlayer" + Random.Range(0, 1000);
+            }
+            
+            // also populate the ip address field with the current local ip address
+            TextField ipField = lobbyViewDoc.rootVisualElement.Q<TextField>("ip-join-text-input");
+            if (ipField != null)
+            {
+                ipField.value = GetLocalIPAddress();
+            }
         }
     }
 }

--- a/FortressForge/Assets/Scripts/UI/Manager/ViewManager.cs
+++ b/FortressForge/Assets/Scripts/UI/Manager/ViewManager.cs
@@ -528,16 +528,18 @@ namespace FortressForge.UI.Manager
             return _playerClient;
         }
 
+        /// <summary>
+        /// Populate the text fields with test data for faster development
+        /// This is only for development purposes and should be removed in production
+        /// </summary>
         private void PopulateTextFieldsForFasterDevelopment()
         {
-            // set the name of the player to "TestPlayer" + random number
             TextField playerNameField = lobbyViewDoc.rootVisualElement.Q<TextField>("PlayerNameTextField");
             if (playerNameField != null)
             {
                 playerNameField.value = "TestPlayer" + Random.Range(0, 1000);
             }
 
-            // also populate the ip address field with the current local ip address
             TextField ipField = lobbyViewDoc.rootVisualElement.Q<TextField>("ip-join-text-input");
             if (ipField != null)
             {

--- a/FortressForge/Assets/Scripts/UI/TopOverlayViewGenerator.cs
+++ b/FortressForge/Assets/Scripts/UI/TopOverlayViewGenerator.cs
@@ -16,7 +16,7 @@ namespace FortressForge.UI
     {
         public UIDocument OverlayUIDocument;
         public VisualTreeAsset ResourceContainerAsset;
-        
+
         private VisualElement _overlayRoot;
         private VisualElement _overlayFrame;
         private Image _overlayImage;
@@ -24,9 +24,9 @@ namespace FortressForge.UI
         private readonly Dictionary<ResourceType, FillableRessourceContainer> _fillableRessourceContainers = new();
 
         /// <summary>
-        /// Initializes the TopTrapezViewGenerator with the provided EconomySystem.
+        /// Initializes the TopTrapezViewGenerator with the provided EconomySync instance.
         /// </summary>
-        /// <param name="economySystem">The EconomySystem to initialize with.</param>
+        /// <param name="economySync"> The EconomySync instance to use for synchronization.</param>
         public void Init(EconomySync economySync)
         {
             if (economySync == null)
@@ -181,18 +181,10 @@ namespace FortressForge.UI
                 amountAutoSizeLabel.text = $"{resource.CurrentAmount}/{resource.MaxAmount}";
                 amountAutoSizeLabel.UpdateFontSize();
             }
-            else
-            {
-                Debug.LogError("Current amount label not found!");
-            }
 
             if (changeRateLabel != null)
             {
                 changeRateLabel.text = resource.DeltaAmount > 0 ? $"+{resource.DeltaAmount}" : resource.DeltaAmount < 0 ? $"{resource.DeltaAmount}" : "0";
-            }
-            else
-            {
-                Debug.LogError("Change rate label not found!");
             }
         }
     }

--- a/FortressForge/Assets/Scripts/UI/UIClickChecker.cs
+++ b/FortressForge/Assets/Scripts/UI/UIClickChecker.cs
@@ -30,7 +30,6 @@ namespace FortressForge.UI
 
             if (uiDocument is null)
             {
-                Debug.Log("No UIDocument found in the scene.");
                 _topTrapezOverlay = null;
                 _bottomTrapezOverlay = null;
                 return;

--- a/FortressForge/Assets/Scripts/UI/UIClickChecker.cs
+++ b/FortressForge/Assets/Scripts/UI/UIClickChecker.cs
@@ -12,18 +12,27 @@ namespace FortressForge.UI
     {
         private static UIClickChecker _instance;
         public static UIClickChecker Instance => _instance ??= new UIClickChecker();
-        
-        private readonly TrapezElement _topTrapezOverlay;
-        private readonly TrapezElement _bottomTrapezOverlay;
+
+        private TrapezElement _topTrapezOverlay;
+        private TrapezElement _bottomTrapezOverlay;
 
         private UIClickChecker()
+        {
+        }
+
+        /// <summary>
+        /// Ensures the overlays are initialized for the current scene.
+        /// </summary>
+        private void InitializeOverlays()
         {
             UIDocument[] uiDocuments = Object.FindObjectsByType<UIDocument>(FindObjectsSortMode.None);
             UIDocument uiDocument = uiDocuments.FirstOrDefault(document => document.name == "BuildingOverlay");
 
-            if (uiDocument == null)
+            if (uiDocument is null)
             {
-                Debug.LogWarning("No UIDocument found in the scene.");
+                Debug.Log("No UIDocument found in the scene.");
+                _topTrapezOverlay = null;
+                _bottomTrapezOverlay = null;
                 return;
             }
 
@@ -31,7 +40,7 @@ namespace FortressForge.UI
             _bottomTrapezOverlay = uiDocument.rootVisualElement.Q<TrapezElement>(className: "bottom-trapez-frame");
 
             if (_topTrapezOverlay == null || _bottomTrapezOverlay == null)
-                Debug.LogWarning("TrapezOverlay not found!");
+                Debug.Log("TrapezOverlay not found!");
         }
 
         /// <summary>
@@ -40,6 +49,11 @@ namespace FortressForge.UI
         /// <returns>True if the mouse is on the overlay, false otherwise.</returns>
         public bool IsMouseOnOverlay()
         {
+            if (_topTrapezOverlay == null || _bottomTrapezOverlay == null)
+            {
+                InitializeOverlays();
+            }
+
             return _topTrapezOverlay?.IsPointInTrapez() == true || _bottomTrapezOverlay?.IsPointInTrapez() == true;
         }
     }

--- a/FortressForge/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
+++ b/FortressForge/Assets/Settings/UniversalRenderPipelineGlobalSettings.asset
@@ -33,28 +33,28 @@ MonoBehaviour:
   m_Settings:
     m_SettingsList:
       m_List:
-      - rid: 6423907300710285389
-      - rid: 6423907300710285390
+      - rid: 8070251555092168800
+      - rid: 8070251555092168801
       - rid: 6852985685364965378
       - rid: 6852985685364965379
       - rid: 6852985685364965380
       - rid: 6852985685364965381
-      - rid: 6423907300710285391
-      - rid: 6423907300710285392
+      - rid: 8070251555092168802
+      - rid: 8070251555092168803
       - rid: 6852985685364965384
       - rid: 6852985685364965385
-      - rid: 6423907300710285393
-      - rid: 6423907300710285394
-      - rid: 6423907300710285395
-      - rid: 6423907300710285396
-      - rid: 6423907300710285397
-      - rid: 6423907300710285398
+      - rid: 8070251555092168804
+      - rid: 8070251555092168805
+      - rid: 8070251555092168806
+      - rid: 8070251555092168807
+      - rid: 8070251555092168808
+      - rid: 8070251555092168809
       - rid: 6852985685364965392
-      - rid: 6423907300710285399
+      - rid: 8070251555092168810
       - rid: 6852985685364965394
       - rid: 8712630790384254976
       - rid: 7319928937949954048
-      - rid: 6423907300710285400
+      - rid: 8070251555092168811
     m_RuntimeSettings:
       m_List:
       - rid: 6852985685364965378
@@ -97,114 +97,6 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 6423907300710285389
-      type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_Version: 0
-        m_StripUnusedPostProcessingVariants: 1
-        m_StripUnusedVariants: 1
-        m_StripScreenCoordOverrideVariants: 1
-    - rid: 6423907300710285390
-      type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
-        m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
-        m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
-        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
-        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
-        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
-        m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
-        m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
-        m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 6423907300710285391
-      type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_Version: 0
-        m_LightShader: {fileID: 4800000, guid: 3f6c848ca3d7bca4bbe846546ac701a1, type: 3}
-        m_ProjectedShadowShader: {fileID: 4800000, guid: ce09d4a80b88c5a4eb9768fab4f1ee00, type: 3}
-        m_SpriteShadowShader: {fileID: 4800000, guid: 44fc62292b65ab04eabcf310e799ccf6, type: 3}
-        m_SpriteUnshadowShader: {fileID: 4800000, guid: de02b375720b5c445afe83cd483bedf3, type: 3}
-        m_GeometryShadowShader: {fileID: 4800000, guid: 19349a0f9a7ed4c48a27445bcf92e5e1, type: 3}
-        m_GeometryUnshadowShader: {fileID: 4800000, guid: 77774d9009bb81447b048c907d4c6273, type: 3}
-        m_FallOffLookup: {fileID: 2800000, guid: 5688ab254e4c0634f8d6c8e0792331ca, type: 3}
-        m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
-        m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-        m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-        m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 6423907300710285392
-      type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
-        m_DefaultParticleMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
-        m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
-        m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
-        m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
-        m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 6423907300710285393
-      type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
-      data:
-        m_Version: 0
-        m_InstanceDataBufferCopyKernels: {fileID: 7200000, guid: f984aeb540ded8b4fbb8a2047ab5b2e2, type: 3}
-        m_InstanceDataBufferUploadKernels: {fileID: 7200000, guid: 53864816eb00f2343b60e1a2c5a262ef, type: 3}
-        m_TransformUpdaterKernels: {fileID: 7200000, guid: 2a567b9b2733f8d47a700c3c85bed75b, type: 3}
-        m_WindDataUpdaterKernels: {fileID: 7200000, guid: fde76746e4fd0ed418c224f6b4084114, type: 3}
-        m_OccluderDepthPyramidKernels: {fileID: 7200000, guid: 08b2b5fb307b0d249860612774a987da, type: 3}
-        m_InstanceOcclusionCullingKernels: {fileID: 7200000, guid: f6d223acabc2f974795a5a7864b50e6c, type: 3}
-        m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
-        m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
-        m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 6423907300710285394
-      type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
-        m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
-        m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 6423907300710285395
-      type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        dilationShader: {fileID: 7200000, guid: 6bb382f7de370af41b775f54182e491d, type: 3}
-        subdivideSceneCS: {fileID: 7200000, guid: bb86f1f0af829fd45b2ebddda1245c22, type: 3}
-        voxelizeSceneShader: {fileID: 4800000, guid: c8b6a681c7b4e2e4785ffab093907f9e, type: 3}
-        traceVirtualOffsetCS: {fileID: -6772857160820960102, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
-        traceVirtualOffsetRT: {fileID: -5126288278712620388, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
-        skyOcclusionCS: {fileID: -6772857160820960102, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
-        skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
-        renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-        renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 6423907300710285396
-      type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        m_ProbeVolumeDisableStreamingAssets: 0
-    - rid: 6423907300710285397
-      type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        probeVolumeDebugShader: {fileID: 4800000, guid: 3b21275fd12d65f49babb5286f040f2d, type: 3}
-        probeVolumeFragmentationDebugShader: {fileID: 4800000, guid: 3a80877c579b9144ebdcc6d923bca303, type: 3}
-        probeVolumeSamplingDebugShader: {fileID: 4800000, guid: bf54e6528c79a224e96346799064c393, type: 3}
-        probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
-        probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
-        numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 6423907300710285398
-      type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_version: 0
-        m_IncludeReferencedInScenes: 0
-        m_IncludeAssetsByLabel: 0
-        m_LabelToInclude: 
-    - rid: 6423907300710285399
-      type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
-      data:
-        m_Version: 1
-        probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
-        probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
-        probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 6423907300710285400
-      type: {class: UniversalRenderPipelineEditorAssets, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
-      data:
-        m_DefaultSettingsVolumeProfile: {fileID: 11400000, guid: eda47df5b85f4f249abf7abd73db2cb2, type: 2}
     - rid: 6852985685364965378
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
@@ -264,6 +156,114 @@ MonoBehaviour:
         m_xrOcclusionMeshPS: {fileID: 4800000, guid: 4431b1f1f743fbf4eb310a967890cbea, type: 3}
         m_xrMirrorViewPS: {fileID: 4800000, guid: d5a307c014552314b9f560906d708772, type: 3}
         m_xrMotionVector: {fileID: 4800000, guid: f89aac1e4f84468418fe30e611dff395, type: 3}
+    - rid: 8070251555092168800
+      type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_Version: 0
+        m_StripUnusedPostProcessingVariants: 1
+        m_StripUnusedVariants: 1
+        m_StripScreenCoordOverrideVariants: 1
+    - rid: 8070251555092168801
+      type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
+        m_AutodeskInteractiveTransparent: {fileID: 4800000, guid: 5c81372d981403744adbdda4433c9c11, type: 3}
+        m_AutodeskInteractiveMasked: {fileID: 4800000, guid: 80aa867ac363ac043847b06ad71604cd, type: 3}
+        m_TerrainDetailLit: {fileID: 4800000, guid: f6783ab646d374f94b199774402a5144, type: 3}
+        m_TerrainDetailGrassBillboard: {fileID: 4800000, guid: 29868e73b638e48ca99a19ea58c48d90, type: 3}
+        m_TerrainDetailGrass: {fileID: 4800000, guid: e507fdfead5ca47e8b9a768b51c291a1, type: 3}
+        m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
+        m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
+        m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
+    - rid: 8070251555092168802
+      type: {class: Renderer2DResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_Version: 0
+        m_LightShader: {fileID: 4800000, guid: 3f6c848ca3d7bca4bbe846546ac701a1, type: 3}
+        m_ProjectedShadowShader: {fileID: 4800000, guid: ce09d4a80b88c5a4eb9768fab4f1ee00, type: 3}
+        m_SpriteShadowShader: {fileID: 4800000, guid: 44fc62292b65ab04eabcf310e799ccf6, type: 3}
+        m_SpriteUnshadowShader: {fileID: 4800000, guid: de02b375720b5c445afe83cd483bedf3, type: 3}
+        m_GeometryShadowShader: {fileID: 4800000, guid: 19349a0f9a7ed4c48a27445bcf92e5e1, type: 3}
+        m_GeometryUnshadowShader: {fileID: 4800000, guid: 77774d9009bb81447b048c907d4c6273, type: 3}
+        m_FallOffLookup: {fileID: 2800000, guid: 5688ab254e4c0634f8d6c8e0792331ca, type: 3}
+        m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
+        m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+        m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+        m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
+    - rid: 8070251555092168803
+      type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+        m_DefaultParticleMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
+        m_DefaultLineMaterial: {fileID: 2100000, guid: e823cd5b5d27c0f4b8256e7c12ee3e6d, type: 2}
+        m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
+        m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
+        m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+    - rid: 8070251555092168804
+      type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
+      data:
+        m_Version: 0
+        m_InstanceDataBufferCopyKernels: {fileID: 7200000, guid: f984aeb540ded8b4fbb8a2047ab5b2e2, type: 3}
+        m_InstanceDataBufferUploadKernels: {fileID: 7200000, guid: 53864816eb00f2343b60e1a2c5a262ef, type: 3}
+        m_TransformUpdaterKernels: {fileID: 7200000, guid: 2a567b9b2733f8d47a700c3c85bed75b, type: 3}
+        m_WindDataUpdaterKernels: {fileID: 7200000, guid: fde76746e4fd0ed418c224f6b4084114, type: 3}
+        m_OccluderDepthPyramidKernels: {fileID: 7200000, guid: 08b2b5fb307b0d249860612774a987da, type: 3}
+        m_InstanceOcclusionCullingKernels: {fileID: 7200000, guid: f6d223acabc2f974795a5a7864b50e6c, type: 3}
+        m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
+        m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
+        m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
+    - rid: 8070251555092168805
+      type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
+        m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
+        m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
+    - rid: 8070251555092168806
+      type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        dilationShader: {fileID: 7200000, guid: 6bb382f7de370af41b775f54182e491d, type: 3}
+        subdivideSceneCS: {fileID: 7200000, guid: bb86f1f0af829fd45b2ebddda1245c22, type: 3}
+        voxelizeSceneShader: {fileID: 4800000, guid: c8b6a681c7b4e2e4785ffab093907f9e, type: 3}
+        traceVirtualOffsetCS: {fileID: -6772857160820960102, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
+        traceVirtualOffsetRT: {fileID: -5126288278712620388, guid: ff2cbab5da58bf04d82c5f34037ed123, type: 3}
+        skyOcclusionCS: {fileID: -6772857160820960102, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
+        skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
+        renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
+        renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
+    - rid: 8070251555092168807
+      type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        m_ProbeVolumeDisableStreamingAssets: 0
+    - rid: 8070251555092168808
+      type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        probeVolumeDebugShader: {fileID: 4800000, guid: 3b21275fd12d65f49babb5286f040f2d, type: 3}
+        probeVolumeFragmentationDebugShader: {fileID: 4800000, guid: 3a80877c579b9144ebdcc6d923bca303, type: 3}
+        probeVolumeSamplingDebugShader: {fileID: 4800000, guid: bf54e6528c79a224e96346799064c393, type: 3}
+        probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
+        probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
+        numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
+    - rid: 8070251555092168809
+      type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_version: 0
+        m_IncludeReferencedInScenes: 0
+        m_IncludeAssetsByLabel: 0
+        m_LabelToInclude: 
+    - rid: 8070251555092168810
+      type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
+      data:
+        m_Version: 1
+        probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
+        probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
+        probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
+    - rid: 8070251555092168811
+      type: {class: UniversalRenderPipelineEditorAssets, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
+      data:
+        m_DefaultSettingsVolumeProfile: {fileID: 11400000, guid: eda47df5b85f4f249abf7abd73db2cb2, type: 2}
     - rid: 8712630790384254976
       type: {class: RenderGraphUtilsResources, ns: UnityEngine.Rendering.RenderGraphModule.Util, asm: Unity.RenderPipelines.Core.Runtime}
       data:

--- a/FortressForge/Assets/Tests/GameOverlay/AutoSizeLabelTests.cs
+++ b/FortressForge/Assets/Tests/GameOverlay/AutoSizeLabelTests.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections;
+using FortressForge.UI.CustomVisualElements;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Object = UnityEngine.Object;
+
+namespace Tests.GameOverlay
+{
+    [TestFixture]
+    public class AutoSizeLabelTests
+    {
+        private AutoSizeLabel _label;
+        private VisualElement _parent;
+        private VisualElement _root;
+
+        [SetUp]
+        public void Setup()
+        {
+            InitUIDocument();
+            _parent = new VisualElement();
+            _root.Add(_parent);
+            _label = new AutoSizeLabel();
+            _parent.Add(_label);
+        }
+
+        /// <summary>
+        /// Initializes the UI document used for testing.
+        /// Loads the prefab from the Resources folder and ensures it is properly instantiated.
+        /// </summary>
+        private void InitUIDocument()
+        {
+            GameObject testingUiDocument = Resources.Load<GameObject>("Prefabs/Tests/UIDocumentTesting");
+            Assert.IsNotNull(testingUiDocument, "TestingUiDocument konnte nicht geladen werden. Stellen Sie sicher, dass es sich im Ordner Resources/Tests befindet.");
+
+            GameObject testingUiDocumentInstantiate = Object.Instantiate(testingUiDocument);
+            Assert.IsNotNull(testingUiDocumentInstantiate, "NetworkManagerObject konnte nicht instanziiert werden.");
+
+            UIDocument uiDocument = testingUiDocumentInstantiate.GetComponent<UIDocument>();
+            Assert.IsNotNull(uiDocument, "UIDocument konnte nicht gefunden werden. Stellen Sie sicher, dass es dem GameObject hinzugefügt wurde.");
+
+            _root = uiDocument.rootVisualElement;
+            Assert.IsNotNull(_root, "Root VisualElement sollte nicht null sein.");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _label = null;
+            _parent = null;
+        }
+
+        [UnityTest]
+        public IEnumerator Constructor_InitializesCorrectly()
+        {
+            AutoSizeLabel newLabel = new();
+
+            Assert.IsNotNull(newLabel);
+            Assert.IsNull(newLabel.hierarchy.parent);
+            Assert.IsEmpty(newLabel.text);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_DoesNothingWhenNoParent()
+        {
+            AutoSizeLabel orphanLabel = new() { text = "Test", style = { fontSize = 0f } };
+            orphanLabel.UpdateFontSize();
+            Assert.AreEqual(0, orphanLabel.resolvedStyle.fontSize);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_AdjustsSizeForParentDimensions()
+        {
+            _parent.style.width = 200;
+            _parent.style.height = 100;
+            _label.text = "Test Text";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            float initialSize = _label.resolvedStyle.fontSize;
+            _label.UpdateFontSize();
+
+            Assert.AreNotEqual(initialSize, _label.resolvedStyle.fontSize);
+            Assert.Greater(_label.resolvedStyle.fontSize, 0);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_RespectsMarginsAndPadding()
+        {
+            _parent.style.width = 200;
+            _parent.style.height = 100;
+            _label.text = "Test Text";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+
+            _label.UpdateFontSize();
+
+            float sizeWithoutConstraints = _label.resolvedStyle.fontSize;
+
+            _label.style.marginLeft = 10;
+            _label.style.marginRight = 10;
+            _label.style.marginTop = 5;
+            _label.style.marginBottom = 5;
+            _label.style.paddingLeft = 5;
+            _label.style.paddingRight = 5;
+            _label.style.paddingTop = 2;
+            _label.style.paddingBottom = 2;
+
+            yield return new WaitUntil(() => Math.Abs(_label.resolvedStyle.paddingBottom - _parent.resolvedStyle.paddingBottom) <= 5,
+                new TimeSpan(0, 0, 5),
+                () => Debug.Log($"PaddingBottom: {_label.resolvedStyle.paddingBottom} >= {_parent.resolvedStyle.paddingBottom}"));
+
+            _label.UpdateFontSize();
+            float sizeWithConstraints = _label.resolvedStyle.fontSize;
+
+            Assert.Less(sizeWithConstraints, sizeWithoutConstraints);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_AppliesThresholdForChanges()
+        {
+            _parent.style.width = 200;
+            _parent.style.height = 100;
+            _label.text = "Test Text";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            float initialSize = _label.resolvedStyle.fontSize;
+
+            _parent.style.width = 205;
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            Assert.AreEqual(initialSize, _label.resolvedStyle.fontSize);
+
+            _parent.style.width = 300;
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            Assert.AreNotEqual(initialSize, _label.resolvedStyle.fontSize);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_HandlesEmptyText()
+        {
+            _parent.style.width = 200;
+            _parent.style.height = 100;
+            _label.text = "";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            Assert.AreEqual(1f, _label.resolvedStyle.fontSize);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_MaintainsMinimumFontSize()
+        {
+            _parent.style.width = 10;
+            _parent.style.height = 5;
+            _label.text = "Very Long Text That Won't Fit";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+
+            Assert.AreEqual(1f, _label.resolvedStyle.fontSize);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UpdateFontSize_ScalesBasedOnWidthConstraint()
+        {
+            _parent.style.height = 1000;
+            _parent.style.width = 50;
+            _label.text = "This text will be width-constrained";
+
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            float widthConstrainedSize = _label.resolvedStyle.fontSize;
+
+            _parent.style.width = 1000;
+            _parent.style.height = 50;
+            yield return WaitForStyleUpdate(_parent, _parent.style.width.value.value, _parent.style.height.value.value);
+            _label.UpdateFontSize();
+            float heightConstrainedSize = _label.resolvedStyle.fontSize;
+
+            Assert.Less(widthConstrainedSize, heightConstrainedSize);
+
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator UxmlSerializedData_CreatesCorrectInstance()
+        {
+            UxmlSerializedData uxmlData = new AutoSizeLabel.UxmlSerializedData();
+            object instance = uxmlData.CreateInstance();
+            Assert.IsNotNull(instance);
+            Assert.IsInstanceOf<AutoSizeLabel>(instance);
+
+            yield return null;
+        }
+
+        /// <summary>
+        /// Waits for the style update of a VisualElement to complete.
+        /// </summary>
+        /// <param name="element">The VisualElement to check.</param>
+        /// <param name="targetWidth">The target width to wait for.</param>
+        /// <param name="targetHeight">The target height to wait for.</param>
+        /// <returns>An IEnumerator for coroutine.</returns>
+        private IEnumerator WaitForStyleUpdate(VisualElement element, float targetWidth, float targetHeight)
+        {
+            yield return new WaitUntil(
+                () => Math.Abs(element.resolvedStyle.width - targetWidth) <= 5 && Math.Abs(element.resolvedStyle.height - targetHeight) <= 5,
+                new TimeSpan(0, 0, 5),
+                () => Debug.Log($"Width: {element.resolvedStyle.width} >= {targetWidth}, Height: {element.resolvedStyle.height} >= {targetHeight}")
+            );
+        }
+    }
+}

--- a/FortressForge/Assets/Tests/GameOverlay/AutoSizeLabelTests.cs.meta
+++ b/FortressForge/Assets/Tests/GameOverlay/AutoSizeLabelTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0ea15f28dd684839a2db639ef864cbb7
+timeCreated: 1745585772

--- a/FortressForge/Assets/Tests/GameOverlay/FillableRessourceContainerTests.cs
+++ b/FortressForge/Assets/Tests/GameOverlay/FillableRessourceContainerTests.cs
@@ -1,0 +1,142 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using FortressForge.UI.CustomVisualElements;
+
+namespace Tests.GameOverlay
+{
+    [TestFixture]
+    public class FillableRessourceContainerTests
+    {
+        private FillableRessourceContainer _container;
+
+        [SetUp]
+        public void Setup()
+        {
+            _container = new FillableRessourceContainer();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _container = null;
+        }
+
+        [Test]
+        public void Constructor_InitializesCorrectly()
+        {
+            Assert.IsNotNull(_container);
+            Assert.AreEqual(1, _container.childCount);
+            Assert.AreEqual(0f, _container.FillPercentage);
+            Assert.IsFalse(_container.IsHorizontal);
+        }
+
+        [Test]
+        public void FillPercentage_SetValue_ClampsBetween0And1()
+        {
+            _container.FillPercentage = -0.5f;
+            Assert.AreEqual(0f, _container.FillPercentage);
+
+            _container.FillPercentage = 1.5f;
+            Assert.AreEqual(1f, _container.FillPercentage);
+
+            _container.FillPercentage = 0.75f;
+            Assert.AreEqual(0.75f, _container.FillPercentage);
+        }
+
+        [Test]
+        public void FillPercentage_UpdatesFillElementDimensions_Vertical()
+        {
+            _container.IsHorizontal = false;
+
+            _container.FillPercentage = 0.5f;
+
+            VisualElement fillElement = _container[0];
+            Assert.AreEqual(Length.Percent(100), fillElement.style.width.value);
+            Assert.AreEqual(Length.Percent(50), fillElement.style.height.value);
+        }
+
+        [Test]
+        public void FillPercentage_UpdatesFillElementDimensions_Horizontal()
+        {
+            _container.IsHorizontal = true;
+
+            _container.FillPercentage = 0.3f;
+
+            VisualElement fillElement = _container[0];
+            Assert.AreEqual(30f, fillElement.style.width.value.value, 0.01f);
+            Assert.AreEqual(100f, fillElement.style.height.value.value, 0.01f);
+
+            Assert.AreEqual(LengthUnit.Percent, fillElement.style.width.value.unit, "Width should be in Percent");
+            Assert.AreEqual(LengthUnit.Percent, fillElement.style.height.value.unit, "Height should be in Percent");
+        }
+
+        [Test]
+        public void IsHorizontal_ChangesOrientation()
+        {
+            _container.IsHorizontal = true;
+
+            Assert.AreEqual(FlexDirection.Row, _container.style.flexDirection.value);
+
+            _container.IsHorizontal = false;
+
+            Assert.AreEqual(FlexDirection.ColumnReverse, _container.style.flexDirection.value);
+        }
+
+        [Test]
+        public void AddStyleForClassList_AddsClassWhenValid()
+        {
+            string testClass = "test-class";
+
+            _container.AddStyleForClassList(testClass);
+
+            Assert.IsTrue(_container.ClassListContains(testClass));
+        }
+
+        [Test]
+        public void AddStyleForClassList_DoesNotAddEmptyOrNullClass()
+        {
+            int initialClassCount = _container.GetClasses().Count();
+
+            _container.AddStyleForClassList(null);
+
+            Assert.AreEqual(initialClassCount, _container.GetClasses().Count());
+
+            _container.AddStyleForClassList("");
+
+            Assert.AreEqual(initialClassCount, _container.GetClasses().Count());
+        }
+
+        [Test]
+        public void UpdateOrientation_SetsCorrectDimensions_Vertical()
+        {
+            _container.FillPercentage = 0.6f;
+            _container.IsHorizontal = true;
+
+            _container.IsHorizontal = false;
+
+            VisualElement fillElement = _container[0];
+            Assert.AreEqual(FlexDirection.ColumnReverse, _container.style.flexDirection.value);
+
+            Assert.AreEqual(100f, fillElement.style.width.value.value, 0.01f);
+            Assert.AreEqual(60f, fillElement.style.height.value.value, 0.01f);
+
+            Assert.AreEqual(LengthUnit.Percent, fillElement.style.width.value.unit, "Width should be in Percent");
+            Assert.AreEqual(LengthUnit.Percent, fillElement.style.height.value.unit, "Height should be in Percent");
+        }
+
+        [Test]
+        public void UpdateOrientation_SetsCorrectDimensions_Horizontal()
+        {
+            _container.FillPercentage = 0.4f;
+            _container.IsHorizontal = false;
+
+            _container.IsHorizontal = true;
+
+            VisualElement fillElement = _container[0];
+            Assert.AreEqual(FlexDirection.Row, _container.style.flexDirection.value);
+            Assert.AreEqual(Length.Percent(100), fillElement.style.height.value);
+            Assert.AreEqual(Length.Percent(40), fillElement.style.width.value);
+        }
+    }
+}

--- a/FortressForge/Assets/Tests/GameOverlay/FillableRessourceContainerTests.cs.meta
+++ b/FortressForge/Assets/Tests/GameOverlay/FillableRessourceContainerTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 971562b71e5e4eaca871d5aaf78a8255
+timeCreated: 1745579760

--- a/FortressForge/Assets/Tests/GameOverlay/TrapezElementTest.cs
+++ b/FortressForge/Assets/Tests/GameOverlay/TrapezElementTest.cs
@@ -143,8 +143,6 @@ namespace Tests.GameOverlay
 
             yield return new WaitUntil(() => _mouse.position.ReadValue() == clickPosition);
 
-            yield return new WaitForSeconds(3f);
-
             Assert.IsFalse(trapezElement.IsPointInTrapez(), "Click should be outside the trapez element.");
 
             yield return null;

--- a/FortressForge/Assets/Tests/LobbyGameRoomGUI/LobbyGameRoomTestBaseSetup.cs
+++ b/FortressForge/Assets/Tests/LobbyGameRoomGUI/LobbyGameRoomTestBaseSetup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using FortressForge.UI.Manager;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -10,6 +11,7 @@ namespace Tests.LobbyGameRoomGUI
     {
         protected VisualElement LobbyMenuRoot;
         private const string TEST_STRING = "TestString";
+        private const string EMPTY_SCENE = "EmptyScene";
 
         [UnitySetUp]
         public virtual IEnumerator SetUp()
@@ -23,6 +25,12 @@ namespace Tests.LobbyGameRoomGUI
 
             LobbyMenuRoot = lobbyMenuGameObject.GetComponent<UIDocument>().rootVisualElement;
             Assert.NotNull(LobbyMenuRoot, "❌ LobbyMenuRoot not found!");
+            
+            GameObject viewManager = GameObject.Find("ViewManager");
+            Assert.NotNull(viewManager, "❌ ViewManager not found!");
+            ViewManager viewManagerComponent = viewManager.GetComponent<ViewManager>();
+            Assert.NotNull(viewManager, "❌ ViewManagerComponent not found!");
+            viewManagerComponent.NextScene = EMPTY_SCENE;
         }
 
         /// <summary>

--- a/FortressForge/ProjectSettings/ProjectSettings.asset
+++ b/FortressForge/ProjectSettings/ProjectSettings.asset
@@ -106,7 +106,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 2
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0


### PR DESCRIPTION
The following things are done:

- Able to connect from Lobby to GameView (to use the GameView without the Lobby you have to enable the NetworkManager manually in the Scene again)
- Removed ChangeRateLabel not found warnings
- Added new Tests
- When unselecting a building the building card also gets deselected
- When there is already a Server running on your Computer then it won't allow you to start a second one (this already didn't work but now it gets detected early and handled gracefully)
- Fixed some issued with AutoSiteLabel (this probably needs some more work but not now)